### PR TITLE
Markdown Compatibility Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,23 +2,16 @@
 
 See example https://yuxin.io
 
-I treat this as an extension for my love [Bear App](http://www.bear-writer.com).
+See guide https://yuxin.io/introduce_miyano/
 
-Let me focus on writting the right thing. Once setup, the blog system will never distract you.
+Not a big thing like [Jekyll](https://jekyllrb.com) which makes you feel free to deep DIY you blog.
 
-Say goodbye to [Yaml Front Matter](https://jekyllrb.com/docs/frontmatter/). (setting up title, tags, date berfore the content everytime)
+The big thing brings free but also along with the complex, which needs you to pay more attention to the
+attributes or the property of the post to adapt to the blog system every time you write a post than the **content** itself which is matter.
 
-Say goodbye to dealing with the files manually. (pictures and markdown files)
+This small tool is designed for [Bear}(http://www.bear-writer.com) lovers.
 
-Say goodbye to ugly writting experience.
-
-Say goodbye to COMPLEX and USELESS.
-
-Just export bearnote files and deploy them on Github Pages.
-
-Just focus on writting...
-
-Isn't that cool?
+Focus on the right thing - writing the content.
 
 ## Installation
 
@@ -26,11 +19,13 @@ Isn't that cool?
 
 ## Usage
 
-I wrote an [introduce](https://yuxin.io/introduce_miyano/) in Chinese.
-
 ### Create new blog
 
     $ miyano new myblog
+
+    ::For Markdown Compatibility Mode::
+
+	$ miyano new myblog -m
 
 ### Change dir
 
@@ -38,10 +33,10 @@ I wrote an [introduce](https://yuxin.io/introduce_miyano/) in Chinese.
 
 ### Build and Try it
 
-    $ miyano build 
+    $ miyano build
 
     $ miyano try
-    
+
 Then open browser and go to `localhost:8000`
 
 ### Push to Github Pages
@@ -49,7 +44,7 @@ Then open browser and go to `localhost:8000`
 #### not support Project Pages
 
     $ miyano push
-    
+
 #### miyano not miyabo
 
 ## Tips

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -2,8 +2,9 @@ Feature: Miyano Cli
 
   Scenario: Show version
     When I run `miyano version`
-    Then the output should contain "Miyano 0.2"
+    Then the output should contain "Miyano 0.3.0"
 
-  Scenario: Create a new project
-    When I run `miyano`
-    Then the output should contain "hahah"
+  Scenario: New Project with markdown compatibility mode
+    When I run `miyano new PROJECT -m`
+    Then I cd to "PROJECT/post"
+    And the file ".compat" should exist

--- a/lib/miyano.rb
+++ b/lib/miyano.rb
@@ -1,3 +1,4 @@
+$VERBOSE = nil
 require "miyano/version"
 require "miyano/site"
 require "miyano/post"

--- a/lib/miyano/build/bear.rb
+++ b/lib/miyano/build/bear.rb
@@ -6,6 +6,7 @@ module Miyano
   class Builder
     protected
     def build_bear
+      require "beardown/compat" if File.exist? "post/.compat"
       files = Dir["post/*.bearnote"]
       files.each do |f|
         name = File.basename(f, ".*")

--- a/lib/miyano/cli.rb
+++ b/lib/miyano/cli.rb
@@ -11,8 +11,10 @@ module Miyano
     end
 
     desc "new [DIR]", "create new blog"
+    method_option :compat, :aliases => "-m", :desc => "Markdown Compatibility Mode"
     def new(dir)
-      url = "https://github.com/wuusn/miyano_template.git"
+      compat = options[:compat]? "_compat" : ""
+      url = "https://github.com/wuusn/miyano_template#{compat}.git"
       `git clone --depth 1 #{url} #{dir}`
       `rm -rf #{dir}/.git*`
     end

--- a/lib/miyano/version.rb
+++ b/lib/miyano/version.rb
@@ -1,3 +1,3 @@
 module Miyano
-  VERSION = "0.2.3"
+  VERSION = "0.3.0"
 end

--- a/miyano.gemspec
+++ b/miyano.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["wuusin@gmail.com"]
 
   spec.summary       = %q{A BearNote Blog system depoly on Github Pages.}
+  spec.homepage      = "https://github.com/wuusn/miyano"
   spec.license       = "MIT"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
@@ -38,5 +39,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "tilt", "~> 2.0.8"
   spec.add_dependency "rubyzip", "~> 1.2.1"
   spec.add_dependency "rouge", "~> 3.1.1"
-  spec.add_dependency "beardown", "0.1.2"
+  spec.add_dependency "beardown", ">= 0.1.4"
+  spec.add_dependency "beardown-compat", ">= 0.1.2"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require "bundler/setup"
 require "miyano"
-
+$VERBOSE = false
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"


### PR DESCRIPTION
An extension beardown-compat for this mode.

A file `post/.compat` to mark this mode.

new cmd: `miyano new blog -m`
